### PR TITLE
Add OCR eval task, reworked

### DIFF
--- a/src/pixparse/app/eval.py
+++ b/src/pixparse/app/eval.py
@@ -20,7 +20,7 @@ from pixparse.framework import (
     setup_logging,
     random_seed,
 )
-from pixparse.utils.s3_utils import load_checkpoint_from_s3
+from pixparse.utils import get_selected_non_default_args
 from pixparse.task import get_eval_task_from_cfg, get_eval_task_cfgs
 
 from chug.webdataset import create_doc_anno_pipe, create_image_text_pipe
@@ -53,9 +53,8 @@ def eval(
     task: TaskEval,
     eval_loaders: dict,
 ):
+    
     device_env = task.device_env
-
-    # load wanted checkpoint
 
     metrics = evaluate(task, eval_loaders)
     # Do something with metrics, print them, log them, save them
@@ -101,10 +100,12 @@ def main():
         output_dir=eval_cfg.output_dir,
         output_enabled=device_env.is_primary(),
     )
+    selected_args = ['task', 'checkpoint_path']
+    rename_map = {'task': 'cfg'}
+    selected_non_default_args = get_selected_non_default_args(eval_cfg, selected_args, rename_map)
 
     task = task_cls(
-        eval_cfg.task,
-        eval_cfg.checkpoint_path,
+        **selected_non_default_args,
         device_env=device_env,
         monitor=monitor,
     )

--- a/src/pixparse/data/preprocess_text.py
+++ b/src/pixparse/data/preprocess_text.py
@@ -41,10 +41,8 @@ def preprocess_text_anno(
     """
     text = task_start_token + anno + tokenizer.eos_token
 
-    tokenizer_fn = tokenize(tokenizer, text, max_position_embeddings)
-
-    text = tokenizer_fn(text)
-
+    text = tokenize(tokenizer, text, max_position_embeddings)
+    
     target = text.clone()
     # model doesn't need to predict pad token
     target[target == tokenizer.pad_token_id] = ignore_id

--- a/src/pixparse/framework/config.py
+++ b/src/pixparse/framework/config.py
@@ -59,5 +59,5 @@ class TaskTrainCfg(TaskCfg):
 class TaskEvalCfg(TaskCfg):
     model: ModelArgs = field(default_factory=ModelArgs)
     tokenizer: Optional[TokenizerCfg] = None
-    image_transforms: str = ""  # Can be "better", "nougat" or ""
+    image_transforms: str = ""  # Can be "better", "nougat" or "basic"
     num_intervals: int = 100

--- a/src/pixparse/layers/bart.py
+++ b/src/pixparse/layers/bart.py
@@ -324,7 +324,6 @@ def _resize_embeddings(weight: torch.Tensor, max_length: int) -> torch.Tensor:
     """
     Helper method to resize embeddings tensor.
     """
-    print(weight.shape)
     if weight.size(0) > max_length:
         # Truncate the positional embeddings if necessary
         resized_weight = weight[:max_length, :]
@@ -336,8 +335,6 @@ def _resize_embeddings(weight: torch.Tensor, max_length: int) -> torch.Tensor:
             mode='linear',
             align_corners=False
         ).squeeze(0).permute(1, 0)
-    print(resized_weight.shape)
-
     return resized_weight
 
 

--- a/src/pixparse/task/task_cruller_eval_ocr.py
+++ b/src/pixparse/task/task_cruller_eval_ocr.py
@@ -2,15 +2,14 @@ import logging
 import time
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Optional
 
 import torch
 import torchvision.transforms as transforms
 
 from pixparse.framework import TaskEvalCfg, TaskEval, DeviceEnv, Monitor
-from pixparse.models import Cruller, ModelCfg, get_model_config
+from pixparse.models import ModelArgs, create_model
 from pixparse.tokenizers import create_tokenizer, TokenizerCfg
-from pixparse.data import preprocess_text_anno
+from pixparse.data import preprocess_text_anno, create_transforms
 from pixparse.utils import get_ocr_metrics
 
 from chug.common import LoaderBundle
@@ -20,28 +19,15 @@ _logger = logging.getLogger(__name__)
 
 @dataclass
 class TaskCrullerEvalOCRCfg(TaskEvalCfg):
-    model_name: Optional[
-        str
-    ] = None  # if model_name set, loads a pre-defined config in models/configs
-    model: ModelCfg = field(
-        default_factory=ModelCfg
-    )  # FIXME rename model_cfg to diff from model_name?
-    tokenizer: TokenizerCfg = field(default_factory=TokenizerCfg)
+    model: ModelArgs = field(default_factory=lambda: ModelArgs(
+        name='cruller_base',  # override model default in spec per task
+    ))
 
     def __post_init__(self):
-        # FIXME figure out how to get command line args to overlay on top pre-defined
-        # config but ONLY if they are specified on cmd line?
-        if self.model_name:
-            model = get_model_config(self.model_name)
-            if model is None:
-                _logger.warning(
-                    f"Model config for {self.model_name} was not found, using defaults."
-                )
-
-            else:
-                self.model = model
-        else:
-            self.model_name = "custom"
+        assert self.model.cfg is not None
+        if self.tokenizer is None:
+            # set tokenizer to text tower model name if not explicitly set
+            self.tokenizer = TokenizerCfg(name=self.model.cfg.text_decoder.name)
 
 
 class TaskCrullerEvalOCR(TaskEval):
@@ -57,6 +43,7 @@ class TaskCrullerEvalOCR(TaskEval):
         cfg: TaskCrullerEvalOCRCfg,
         device_env: DeviceEnv,
         monitor: Monitor = None,
+        checkpoint_path: str = "",
     ):
         super().__init__(
             cfg=cfg,
@@ -64,6 +51,7 @@ class TaskCrullerEvalOCR(TaskEval):
             monitor=monitor,
         )
         self.cfg = cfg
+        model_cfg = self.cfg.model.cfg
         # NOTE dtype is currently being used as 'amp dtype' only, ie the low precision type,
         #  we may want to differentiate different precision modes such as
         #  amp + dtype, pure float16/bfloat16, custom mixed prec, etc
@@ -75,7 +63,7 @@ class TaskCrullerEvalOCR(TaskEval):
 
         self.task_start_token = "<s_pretrain>"
         self.prompt_end_token = self.task_start_token
-        self.max_position_embeddings = cfg.model.text_decoder.max_length
+        self.max_position_embeddings = model_cfg.text_decoder.max_length
         self.text_anno_fn = True
         self.tokenizer = create_tokenizer(cfg.tokenizer)
         special_tokens = [
@@ -89,7 +77,8 @@ class TaskCrullerEvalOCR(TaskEval):
 
         self.vocab_size = len(self.tokenizer)
 
-        preproc_fn = preprocess_text_anno
+        preproc_fn = preprocess_text_anno 
+        
         self.anno_preprocess_eval = partial(
             preproc_fn,
             tokenizer=self.tokenizer,
@@ -98,48 +87,22 @@ class TaskCrullerEvalOCR(TaskEval):
             prompt_end_token=self.prompt_end_token,
         )
 
-        self.model = Cruller(cfg.model)
-
-        # We need to resize the token embeddings after the model has been initialized
-        if newly_added_num > 0:
-            self.model.text_decoder.trunk.resize_token_embeddings(
-                len(self.tokenizer)
-            )
+        self.model = create_model(
+            model_cfg,
+            pretrained=checkpoint_path, 
+            new_vocab_size=self.vocab_size,
+        )
 
         self.has_no_sync = False
-        self.num_image_chs = 1 if cfg.model.image_encoder.image_fmt == "L" else 3
 
-        # TODO refactor, used in many tasks
-        img_mean = self.model.image_encoder.trunk.pretrained_cfg["mean"]
-        img_std = self.model.image_encoder.trunk.pretrained_cfg["std"]
-
-        self.img_mean = (
-            sum(img_mean) / len(img_mean)
-            if cfg.model.image_encoder.image_fmt == "L"
-            else img_mean
-        )
-        self.img_std = (
-            sum(img_std) / len(img_std)
-            if cfg.model.image_encoder.image_fmt == "L"
-            else img_std
-        )
-
-        # preprocessors cross both the task/model & dataset domain,
-        # created within task here and passed to data loaders
-        self.image_preprocess_eval = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Resize(
-                    cfg.model.image_encoder.image_size,
-                    interpolation=transforms.InterpolationMode.BICUBIC,
-                    antialias=True,
-                ),
-                # transforms.CenterCrop(448),  # FIXME need better aspect preserving resize & pad
-                transforms.Normalize(
-                    mean=self.img_mean,
-                    std=self.img_std,
-                ),
-            ]
+        self.image_input_cfg = self.model.image_encoder.traits.get('input')
+        self.image_preprocess_eval = create_transforms(
+            self.cfg.image_transforms,
+            input_cfg=self.image_input_cfg,
+            training=False,
+            interpolation='bicubic',
+            crop_margin=False,  # True?
+            align_long_axis=False,
         )
 
         # TODO These metrics have to be organized as dicts of dicts.
@@ -165,13 +128,17 @@ class TaskCrullerEvalOCR(TaskEval):
 
         return wrapper
 
+    def collate_fn(self, batch):
+        # For FUNSD, there is no collation needed as data is prepacked through chug
+        # but that makes this task interdependent with the data.
+        # Probably fine as a specific eval task, rename to eval_ocr_FUNSD?
+        return None
+
     def setup(self):
         """
         Weight initialization is deferred here. The state_dict to be loaded has to be created before, within the task.
         """
         device = self.device_env.device
-        self.model.load_state_dict(self.resume_state_dict)
-
         self.model.eval()
         self.model.to(device)
 

--- a/src/pixparse/utils/ocr_utils.py
+++ b/src/pixparse/utils/ocr_utils.py
@@ -76,7 +76,6 @@ def get_ocr_metrics(
         decoded_texts = [
             re.sub(r"<.*?>", "", re.sub("\n", " ", text)) for text in decoded_texts
         ]
-
         # FIXME sometimes we are decoding no text at all after cleaning
         filtered = [
             (ref, pred)


### PR DESCRIPTION
Should be launchable with 

```python
python -m pixparse.app.eval \
  --task cruller_eval_ocr \
  --source "pipe:aws s3 cp s3://....FUNSD_s16/FUNSD-0000{00..12}.tar -" \
  --format webdataset \
  --num-samples 400 \
  --batch-size 16 \
  --num-workers 8 \
  --model.name cruller_swin_384_to_1920 \
  --dtype bfloat16 \
  --output-dir /fsx/pablo/metrics_ocr \
  --checkpoint-path ....checkpoint-29.pt 

```